### PR TITLE
Added event selection to question creation page

### DIFF
--- a/course/forms/forms.py
+++ b/course/forms/forms.py
@@ -2,8 +2,10 @@ from django import forms
 from django.forms import TextInput, widgets, Textarea
 from django.template.loader import render_to_string
 from djrichtextfield.widgets import RichTextWidget
+
+from canvas.models import Event
+
 from course.fields import JSONFormField
-from django.contrib.staticfiles.storage import staticfiles_storage
 from course.models.models import DIFFICULTY_CHOICES, QuestionCategory
 from course.widgets import JSONEditor
 
@@ -54,6 +56,15 @@ class ProblemCreateForm(forms.ModelForm):
         please don't add any variables
         and delete the existing ones.
         """
+    )
+
+    event = forms.ModelChoiceField(
+        label="Type",
+        required=False,
+        queryset=Event.objects.all(),
+        widget=widgets.Select(attrs={
+            'class': 'form-control',
+        })
     )
 
 

--- a/course/forms/java.py
+++ b/course/forms/java.py
@@ -6,7 +6,7 @@ class JavaQuestionForm(JunitProblemCreateForm):
     class Meta:
         model = JavaQuestion
         fields = (
-            'title', 'difficulty', 'category', 'text', 'junit_template', 'additional_file_name', 'variables',)
+            'title', 'difficulty', 'category', 'text', 'junit_template', 'additional_file_name', 'variables', 'event')
         exclude = ('answer',)
 
     answer = None

--- a/course/forms/multiple_choice.py
+++ b/course/forms/multiple_choice.py
@@ -17,7 +17,7 @@ class CheckboxQuestionForm(ChoiceProblemCreateForm):
     class Meta:
         model = CheckboxQuestion
         fields = (
-            'title', 'difficulty', 'category', 'text', 'visible_distractor_count', 'variables')
+            'title', 'difficulty', 'category', 'text', 'visible_distractor_count', 'variables', 'event')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -36,7 +36,7 @@ class MultipleChoiceQuestionForm(ChoiceProblemCreateForm):
     class Meta:
         model = MultipleChoiceQuestion
         fields = (
-            'title', 'difficulty', 'category', 'text', 'visible_distractor_count', 'variables')
+            'title', 'difficulty', 'category', 'text', 'visible_distractor_count', 'variables', 'event')
 
     visible_distractor_count = forms.ChoiceField(
         choices=[('999', 'All'), ('2', '2'), ('3', '3')],

--- a/course/forms/parsons.py
+++ b/course/forms/parsons.py
@@ -9,7 +9,8 @@ class ParsonsQuestionForm(JunitProblemCreateForm):
     class Meta:
         model = ParsonsQuestion
         fields = (
-            'title', 'difficulty', 'category', 'text', 'lines', 'junit_template', 'additional_file_name', 'variables',)
+            'title', 'difficulty', 'category', 'text', 'lines', 'junit_template', 'additional_file_name', 'variables',
+            'event')
         exclude = ('answer',)
 
     answer = None

--- a/course/utils/utils.py
+++ b/course/utils/utils.py
@@ -69,7 +69,7 @@ class QuestionCreateException(Exception):
 def create_multiple_choice_question(pk=None, title=None, text=None, answer=None, max_submission_allowed=None,
                                     tutorial=None, author=None, category=None, difficulty=None, is_verified=None,
                                     variables=None, choices=None, visible_distractor_count=None, answer_text=None,
-                                    distractors=None):
+                                    distractors=None, event=None):
     if not answer and not answer_text:
         raise QuestionCreateException(
             message="answer or answer_text should be provided!",
@@ -112,7 +112,8 @@ def create_multiple_choice_question(pk=None, title=None, text=None, answer=None,
                                                             category=category, difficulty=difficulty,
                                                             is_verified=is_verified,
                                                             variables=variables, choices=choices,
-                                                            visible_distractor_count=visible_distractor_count)
+                                                            visible_distractor_count=visible_distractor_count,
+                                                            event=event)
     else:
         try:
             question = MultipleChoiceQuestion(title=title, text=text, answer=answer,
@@ -120,7 +121,8 @@ def create_multiple_choice_question(pk=None, title=None, text=None, answer=None,
                                               author=author,
                                               category=category, difficulty=difficulty, is_verified=is_verified,
                                               variables=variables, choices=choices,
-                                              visible_distractor_count=visible_distractor_count)
+                                              visible_distractor_count=visible_distractor_count,
+                                              event=event)
             question.save()
         except Exception as e:
             print(e)
@@ -133,7 +135,8 @@ def create_multiple_choice_question(pk=None, title=None, text=None, answer=None,
 
 
 def create_java_question(pk=None, title=None, text=None, max_submission_allowed=None, tutorial=None, author=None,
-                         category=None, difficulty=None, is_verified=None, junit_template=None, additional_file_name=None):
+                         category=None, difficulty=None, is_verified=None, junit_template=None, additional_file_name=None,
+                         event=None):
     if not max_submission_allowed:
         max_submission_allowed = 5
     if not is_verified:
@@ -151,7 +154,8 @@ def create_java_question(pk=None, title=None, text=None, max_submission_allowed=
             difficulty=difficulty,
             is_verified=is_verified,
             junit_template=junit_template,
-            additional_file_name=additional_file_name
+            additional_file_name=additional_file_name,
+            event=event
         )
     else:
         question = JavaQuestion(
@@ -164,6 +168,7 @@ def create_java_question(pk=None, title=None, text=None, max_submission_allowed=
             difficulty=difficulty,
             is_verified=is_verified,
             junit_template=junit_template,
-            additional_file_name=additional_file_name
+            additional_file_name=additional_file_name,
+            event=event
         )
         question.save()

--- a/course/views/multiple_choice.py
+++ b/course/views/multiple_choice.py
@@ -1,4 +1,3 @@
-import djangosphinx
 from django.contrib import messages
 from django.forms import formset_factory
 from django.shortcuts import render
@@ -31,6 +30,7 @@ def _multiple_choice_question_create_view(request, header, question_form_class, 
                     answer_text=correct_answer_formset.forms[0].cleaned_data['text'],
                     distractors=[form.cleaned_data['text'] for form in distractor_answer_formset.forms if
                                  not form.cleaned_data['DELETE']],
+                    event=form.cleaned_data['event']
                 )
                 messages.add_message(request, messages.SUCCESS, 'Problem was created successfully')
                 form = question_form_class()
@@ -110,6 +110,7 @@ def _multiple_choice_question_edit_view(request, question):
                     answer_text=correct_answer_formset.forms[0].cleaned_data['text'],
                     distractors=[form.cleaned_data['text'] for form in distractor_answer_formset.forms if
                                  not form.cleaned_data['DELETE']],
+                    event=form.cleaned_data['event'],
                 )
                 messages.add_message(request, messages.SUCCESS, 'Problem saved successfully')
             except QuestionCreateException as e:


### PR DESCRIPTION
## Summary
- Added ability to assign question to an event when creating the question for all of MCQ, Checkbox, Java, and Parsons questions
- Added ability to edit a questions event from the edit question screen
- Changed event label to "Type"
- Removed unused import statements