### PR TITLE
CG-71: cleaned up events page

### DIFF
--- a/canvas/templates/canvas/event_problem_set.html
+++ b/canvas/templates/canvas/event_problem_set.html
@@ -1,6 +1,10 @@
 {% extends 'base.html' %}
 
+{% block header %}
+    {{ event.name }}
+{% endblock %}
+
 {% block content %}
-    <h2>{{ event.name }} Questions</h2>
+    <h2>Questions</h2>
     {% include 'canvas/problem_set_snippet.html' %}
 {% endblock %}

--- a/canvas/templates/canvas/problem_set_snippet.html
+++ b/canvas/templates/canvas/problem_set_snippet.html
@@ -4,8 +4,8 @@
         <th scope="col">#</th>
         <th scope="col">Category</th>
         <th scope="col">Sub&nbsp;Category</th>
-        <th scope="col">Difficulty</th>
-        <th scope="col">Token&nbsp;Value</th>
+        <th scope="col">Format</th>
+        <th scope="col">Tokens&nbsp;Earned</th>
         <th scope="col">Status</th>
         <th scope="col">Num&nbsp;Attempts</th>
         <th scope="col">Action</th>
@@ -17,8 +17,8 @@
             <th scope="row">{{ forloop.counter }}</th>
             <td>{{ uqj.question.category.parent }}</td>
             <td>{{ uqj.question.category.name }}</td>
-            <td>{{ uqj.question.get_difficulty_display | safe }}</td>
-            <td>{{ uqj.question.token_value | floatformat:0 }}</td>
+            <td>{{ uqj.question.type_name }}</td>
+            <td>{{ uqj.formatted_current_tokens_received }}</td>
             <td>{{ uqj.status }}</td>
             <td>
                 {{ uqj.num_attempts }} / {{ uqj.question.max_submission_allowed }}

--- a/course/models/models.py
+++ b/course/models/models.py
@@ -231,6 +231,10 @@ class UserQuestionJunction(models.Model):
             return "Unsolved"
         return "New"
 
+    @property
+    def formatted_current_tokens_received(self):
+        return str(self.tokens_received) + "/" + str(self.question.token_value)
+
     def save(self, **kwargs):
         self.is_solved = self.submissions.filter(is_correct=True).exists()
         self.is_partially_solved = not self.is_solved and self.submissions.filter(is_partially_correct=True).exists()


### PR DESCRIPTION
## Summary
- removed difficulty level column
- added the question format (ie. MC, Java, Parsons, etc). The word `format` was used because `type` is already used to refer to if a question is a practice, assignment or exam question
- updated `Token Value` column to `Tokens Earned` and displays `tokens earned / maximum tokens possible to earn`
- moved event name to the header section of the events page

![image](https://user-images.githubusercontent.com/43148498/98594152-1ac64f00-2289-11eb-83e1-b1ceb65f68f6.png)

