### PR TITLE
CG-76: Cleaned up Question page

### DIFF
--- a/canvas/templates/canvas/problem_set_snippet.html
+++ b/canvas/templates/canvas/problem_set_snippet.html
@@ -12,7 +12,7 @@
     </tr>
     </thead>
     <tbody>
-    {% for uqj in uqjs %}
+    {% for key, uqj in uqjs.items %}
         <tr class="{{ uqj.status_class }}">
             <th scope="row">{{ forloop.counter }}</th>
             <td>{{ uqj.question.category.parent }}</td>
@@ -24,7 +24,7 @@
                 {{ uqj.num_attempts }} / {{ uqj.question.max_submission_allowed }}
             </td>
             <td>
-                <a href="{% url 'course:question_view' uqj.question.pk %}" class="btn btn-primary">Open</a>
+                <a href="{% url 'course:question_view' pk=uqj.question.pk key=key %}" class="btn btn-primary">Open</a>
                 {% if user.is_teacher %}
                     <a href="{% url 'course:question_edit' uqj.question.pk %}" class="btn btn-warning">Edit</a>
                 {% endif %}

--- a/canvas/views/views.py
+++ b/canvas/views/views.py
@@ -66,9 +66,13 @@ def event_problem_set(request, event_id):
 
     uqjs = UserQuestionJunction.objects.filter(user=request.user, question__event=event).all()
 
+    uqjs_dict = {}
+    for i in range(len(uqjs)):
+        uqjs_dict[i+1] = uqjs[i]
+
     return render(request, 'canvas/event_problem_set.html', {
         'event': event,
-        'uqjs': uqjs,
+        'uqjs': uqjs_dict,
         'is_instructor': event.course.has_edit_permission(request.user),
     })
 

--- a/canvas/views/views.py
+++ b/canvas/views/views.py
@@ -68,7 +68,7 @@ def event_problem_set(request, event_id):
 
     uqjs_dict = {}
     for i in range(len(uqjs)):
-        uqjs_dict[i+1] = uqjs[i]
+        uqjs_dict[i + 1] = uqjs[i]
 
     return render(request, 'canvas/event_problem_set.html', {
         'event': event,

--- a/course/models/models.py
+++ b/course/models/models.py
@@ -219,6 +219,9 @@ class UserQuestionJunction(models.Model):
     def num_attempts(self):
         return self.submissions.count()
 
+    def formatted_num_attempts(self):
+        return str(self.num_attempts()) + "/" + str(self.question.max_submission_allowed)
+
     @property
     def status_class(self):
         if self.is_solved:

--- a/course/templates/base_question_view.html
+++ b/course/templates/base_question_view.html
@@ -12,15 +12,16 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML"></script>
 {% endblock %}
 
+{% block header %}
+    {{ "Question Summary" }}
+{% endblock %}
+
 {% block content %}
 
     <table class="table">
         <thead>
         <tr>
-            <th scope="col">ID</th>
-            <th scope="col">Type</th>
             <th scope="col">Category</th>
-            <th scope="col">Difficulty</th>
             <th scope="col">Token&nbspValue</th>
             <th scope="col">Status</th>
             <th scope="col">Num&nbsp;Attempts</th>
@@ -28,25 +29,23 @@
         </thead>
         <tbody>
         <tr class="{% if question.is_solved %}table-success{% endif %}{% if question.is_wrong %}table-danger{% endif %}{% if question.is_partially_correct %}table-warning{% endif %}">
-            <td>{{ question.pk }}</td>
-            <td>{{ question.type_name | title }}</td>
             <td>{{ question.category }}</td>
-            <td>{{ question.get_difficulty_display | safe }}</td>
             <td>{{ question.token_value | floatformat:0 }}</td>
             <td>{{ uqj.status }}</td>
-            <td>{{ uqj.num_attempts }}</td>
+            <td>{{ uqj.formatted_num_attempts }}</td>
         </tr>
         </tbody>
     </table>
 
     <div class="card">
-        <div class="card-header"><h1>{{ question.title }}</h1></div>
+    <div class="card-header"><h1>{{ title }}</h1></div>
         <div class="card-body">
             <div>{% autoescape off %}{{ uqj.get_rendered_text }}{% endautoescape %}</div>
         </div>
     </div>
 
     <div class="card my-1">
+        <div class="card-header"><h1>My Answer</h1></div>
         <div class="card-body">
             {% if uqj.is_allowed_to_submit %}
                 {% block submit_form %}
@@ -64,7 +63,11 @@
         {% include 'variables_debug_snippet.html' %}
     {% endif %}
 
-    <h2>My Past Submissions</h2>
-    {% include 'past_submissions_snippet.html' with submissions=uqj.submissions.all %}
+    <div class="card my-1">
+        <div class="card-header"><h1>My Past Submissions</h1></div>
+        <div class="card-body">
+            {% include 'past_submissions_snippet.html' with submissions=uqj.submissions.all %}
+        </div>
+    </div>
 
 {% endblock %}

--- a/course/templates/java_question.html
+++ b/course/templates/java_question.html
@@ -1,39 +1,39 @@
 {% extends 'base_question_view.html' %}
 
 {% block submit_form %}
+    <div>
+        <label for="answer-text">Submit your Java code as Text or Submit a Java file</label>
+        <form method="post" enctype="multipart/form-data">
+            {% csrf_token %}
 
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-
-        <ul class="nav nav-tabs" id="submission-tab" role="tablist">
-            <li class="nav-item" role="presentation">
-                <a class="nav-link active" id="text-tab" data-toggle="tab" href="#text" role="tab" aria-controls="text"
-                   aria-selected="true">Text</a>
-            </li>
-            <li class="nav-item" role="presentation">
-                <a class="nav-link" id="file-tab" data-toggle="tab" href="#file" role="tab"
-                   aria-controls="file"
-                   aria-selected="false">File</a>
-            </li>
-        </ul>
-        <div class="tab-content" id="myTabContent">
-            <div class="tab-pane fade show active" id="text" role="tabpanel" aria-labelledby="text-tab">
-                <div class="form-group">
-                    <label for="answer-text">Submit Java Code as Text</label>
-                    <textarea name="answer-text" id="answer-text" class="form-control"> </textarea>
+            <ul class="nav nav-tabs" id="submission-tab" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link active" id="text-tab" data-toggle="tab" href="#text" role="tab" aria-controls="text"
+                       aria-selected="true">Text</a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link" id="file-tab" data-toggle="tab" href="#file" role="tab"
+                       aria-controls="file"
+                       aria-selected="false">File</a>
+                </li>
+            </ul>
+            <div class="tab-content" id="myTabContent">
+                <div class="tab-pane fade show active" id="text" role="tabpanel" aria-labelledby="text-tab">
+                    <div class="form-group">
+                        <textarea name="answer-text" id="answer-text" class="form-control"> </textarea>
+                    </div>
+                </div>
+                <div class="tab-pane fade" id="file" role="tabpanel" aria-labelledby="file-tab">
+                    <div class="form-group">
+                        <input type="file" name="answer-file" id="answer-file" class="form-control">
+                    </div>
                 </div>
             </div>
-            <div class="tab-pane fade" id="file" role="tabpanel" aria-labelledby="file-tab">
-                <div class="form-group">
-                    <label for="answer-file">Submit a Java File</label>
-                    <input type="file" name="answer-file" id="answer-file" class="form-control">
-                </div>
-            </div>
-        </div>
 
-        <div class="form-group row ml-0">
-            <button type="submit" class="btn btn-success"> Submit</button>
-        </div>
-    </form>
+            <div class="form-group row ml-0">
+                <button type="submit" class="btn btn-success"> Submit</button>
+            </div>
+        </form>
+    </div>
 
 {% endblock %}

--- a/course/urls.py
+++ b/course/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('question/<int:pk>/delete', question_delete_view, name='question_delete'),
     path('question/<int:pk>/edit', question_edit_view, name='question_edit'),
     path('question/<int:pk>/', question_view, name='question_view'),
+    path('question/<int:pk>/key/<int:key>', question_view, name='question_view'),
     path('problem-set', problem_set_view, name='problem_set'),
     path('token-values', token_values_table_view, name='token_values'),
 ]

--- a/course/utils/utils.py
+++ b/course/utils/utils.py
@@ -175,3 +175,12 @@ def create_java_question(pk=None, title=None, text=None, max_submission_allowed=
             event=event,
         )
         question.save()
+
+
+def get_question_title(user, question, key):
+    if key is None:
+        return question.title
+    elif question.course.is_instructor(user) and key is not None:
+        return "Question " + str(key) + " - " + question.title
+    else:
+        return "Question " + str(key)

--- a/course/views/java.py
+++ b/course/views/java.py
@@ -5,7 +5,7 @@ from course.exceptions import SubmissionException
 from course.forms.java import JavaQuestionForm
 from course.models.models import JavaSubmission
 from course.utils.submissions import submit_solution
-from course.utils.utils import get_user_question_junction
+from course.utils.utils import get_user_question_junction, get_question_title
 
 
 def _java_question_create_view(request, header, question_form_class):
@@ -46,12 +46,13 @@ def _java_question_edit_view(request, question):
     })
 
 
-def _java_question_view(request, question):
+def _java_question_view(request, question, key):
     def return_render():
         return render(request, 'java_question.html', {
             'question': question,
             'uqj': get_user_question_junction(request.user, question),
             'submission_class': JavaSubmission,
+            'title': get_question_title(request.user, question, key)
         })
 
     if request.method == "POST":

--- a/course/views/multiple_choice.py
+++ b/course/views/multiple_choice.py
@@ -6,7 +6,7 @@ from course.exceptions import SubmissionException
 from course.forms.multiple_choice import MultipleChoiceQuestionForm, ChoiceForm
 from course.models.models import MultipleChoiceSubmission
 from course.utils.submissions import submit_solution
-from course.utils.utils import create_multiple_choice_question, QuestionCreateException, get_user_question_junction
+from course.utils.utils import create_multiple_choice_question, QuestionCreateException, get_user_question_junction, get_question_title
 
 
 def _multiple_choice_question_create_view(request, header, question_form_class, correct_answer_formset_class,
@@ -54,7 +54,7 @@ def _multiple_choice_question_create_view(request, header, question_form_class, 
     })
 
 
-def _multiple_choice_question_view(request, question, template_name):
+def _multiple_choice_question_view(request, question, template_name, key):
     if request.method == 'POST':
 
         answer = request.POST.get('answer', None)
@@ -84,6 +84,7 @@ def _multiple_choice_question_view(request, question, template_name):
         'question': question,
         'uqj': get_user_question_junction(request.user, question),
         'submission_class': MultipleChoiceSubmission,
+        'title': get_question_title(request.user, question, key)
     })
 
 

--- a/course/views/multiple_choice.py
+++ b/course/views/multiple_choice.py
@@ -6,7 +6,8 @@ from course.exceptions import SubmissionException
 from course.forms.multiple_choice import MultipleChoiceQuestionForm, ChoiceForm
 from course.models.models import MultipleChoiceSubmission
 from course.utils.submissions import submit_solution
-from course.utils.utils import create_multiple_choice_question, QuestionCreateException, get_user_question_junction, get_question_title
+from course.utils.utils import create_multiple_choice_question, QuestionCreateException, get_user_question_junction, \
+    get_question_title
 
 
 def _multiple_choice_question_create_view(request, header, question_form_class, correct_answer_formset_class,

--- a/course/views/parsons.py
+++ b/course/views/parsons.py
@@ -5,7 +5,7 @@ from course.exceptions import SubmissionException
 from course.forms.parsons import ParsonsQuestionForm
 from course.models.parsons_question import ParsonsSubmission
 from course.utils.submissions import submit_solution
-from course.utils.utils import get_user_question_junction
+from course.utils.utils import get_user_question_junction, get_question_title
 
 
 def _parsons_question_create_view(request, header):
@@ -51,12 +51,13 @@ def _parsons_question_edit_view(request, question):
     })
 
 
-def _parsons_question_view(request, question):
+def _parsons_question_view(request, question, key):
     def return_render():
         return render(request, 'parsons_question.html', {
             'question': question,
             'uqj': get_user_question_junction(request.user, question),
             'submission_class': ParsonsSubmission,
+            'title': get_question_title(request.user, question, key)
         })
 
     if request.method == "POST":

--- a/course/views/views.py
+++ b/course/views/views.py
@@ -57,7 +57,7 @@ def parsons_question_create_view(request):
     return _parsons_question_create_view(request, 'New Parsons Question')
 
 
-def question_view(request, pk):
+def question_view(request, pk, key=None):
     question = get_object_or_404(Question, pk=pk)
 
     if not question.has_view_permission(request.user):
@@ -67,16 +67,16 @@ def question_view(request, pk):
     uqj.viewed()
 
     if isinstance(question, JavaQuestion):
-        return _java_question_view(request, question)
+        return _java_question_view(request, question, key)
 
     if isinstance(question, CheckboxQuestion):
-        return _multiple_choice_question_view(request, question, 'checkbox_question.html')
+        return _multiple_choice_question_view(request, question, 'checkbox_question.html', key)
 
     if isinstance(question, MultipleChoiceQuestion):
-        return _multiple_choice_question_view(request, question, 'multiple_choice_question.html')
+        return _multiple_choice_question_view(request, question, 'multiple_choice_question.html', key)
 
     if isinstance(question, ParsonsQuestion):
-        return _parsons_question_view(request, question)
+        return _parsons_question_view(request, question, key)
 
     raise Http404()
 


### PR DESCRIPTION
# Requested Changes

- [x] in the table at the top of the page, remove the `difficulty`, `id`, and `type` fields
- [x] add instructions for the student to submit their answer(s)
- [x] add default names to all questions (students will see the default name, instructors will see the default name and the name they gave the question) when you navigate to the Question page from the Event page
- [x] put "My Submission" in a card
- [x] add total number of attempts (attempts used / total allowed attempts)
- [x] add a title in the header
- [x] Add another header "Your Answer" and "Your Past Submissions"

# Java Question
![java_question](https://user-images.githubusercontent.com/43148498/98887692-53158b00-244b-11eb-95a4-6f9bfa9edf58.png)

# Parsons Question
![parsons_question](https://user-images.githubusercontent.com/43148498/98887509-f31ee480-244a-11eb-8db2-51140da5cbc3.png)

# Multiple Choice Question
![multiple_choice_question](https://user-images.githubusercontent.com/43148498/98888026-ee0e6500-244b-11eb-91b2-917db8a5abf9.png)
